### PR TITLE
Added xtend-gen to build.properties

### DIFF
--- a/bundles/tools.mdsd.ecoreworkflow.mwe2lib.xtext/META-INF/MANIFEST.MF
+++ b/bundles/tools.mdsd.ecoreworkflow.mwe2lib.xtext/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Require-Bundle: org.eclipse.emf.mwe.utils,
  org.eclipse.xtend.lib
 Import-Package: com.google.inject;version="1.3.0",
  org.eclipse.core.runtime
+Export-Package: tools.mdsd.ecoreworkflow.mwe2lib.xtext.config

--- a/bundles/tools.mdsd.ecoreworkflow.mwe2lib.xtext/build.properties
+++ b/bundles/tools.mdsd.ecoreworkflow.mwe2lib.xtext/build.properties
@@ -1,4 +1,5 @@
-source.. = src/
+source.. = src/,\
+           xtend-gen/
 output.. = bin/
 bin.includes = META-INF/,\
                .


### PR DESCRIPTION
In the previous PR the xtend-gen folder was missing from build.properties. Hence, dependent projects could not resolve the config class, as the xtend-generated java code was never built.