### PR TITLE
Adapted Gap Pattern to properly support Factory extension

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,7 +3,7 @@
 	<extension>
 		<groupId>org.eclipse.tycho.extras</groupId>
 		<artifactId>tycho-pomless</artifactId>
-		<version>1.6.0</version>
+		<version>1.7.0</version>
 	</extension>
 	<extension>
 		<groupId>org.palladiosimulator</groupId>

--- a/bundles/tools.mdsd.ecoreworkflow.mwe2lib.xtext/META-INF/MANIFEST.MF
+++ b/bundles/tools.mdsd.ecoreworkflow.mwe2lib.xtext/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: MDSD.tools Ecore Workflow Mwe2 Library for Xtext
 Bundle-SymbolicName: tools.mdsd.ecoreworkflow.mwe2lib.xtext
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.1.qualifier
 Automatic-Module-Name: tools.mdsd.ecoreworkflow.mwe2lib.xtext
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.emf.mwe.utils,

--- a/bundles/tools.mdsd.ecoreworkflow.mwe2lib/META-INF/MANIFEST.MF
+++ b/bundles/tools.mdsd.ecoreworkflow.mwe2lib/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: MDSD Tools Ecore Workflow Mwe2 Library
 Bundle-SymbolicName: tools.mdsd.ecoreworkflow.mwe2lib
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.1.1.qualifier
 Automatic-Module-Name: tools.mdsd.ecoreworkflow.mwe2lib
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: tools.mdsd.ecoreworkflow.mwe2lib.bean,

--- a/bundles/tools.mdsd.ecoreworkflow.mwe2lib/src/tools/mdsd/ecoreworkflow/mwe2lib/component/GapPatternPostProcessor.java
+++ b/bundles/tools.mdsd.ecoreworkflow.mwe2lib/src/tools/mdsd/ecoreworkflow/mwe2lib/component/GapPatternPostProcessor.java
@@ -29,14 +29,12 @@ import org.eclipse.emf.mwe.core.lib.AbstractWorkflowComponent2;
 import org.eclipse.emf.mwe.core.monitor.ProgressMonitor;
 
 public class GapPatternPostProcessor extends AbstractWorkflowComponent2 {
-	private static final String CLASSNAME_MATCHER_PATTERN =
-			"(?<=[^a-zA-Z\\d_$])(%s)(?=[^a-zA-Z\\d_$])";
-	
 	private static final String JAVAFILE_MATCHER_PATTERN = 
 			"([^\\n\\s]*).java$";
 
 	private static final Log LOG = LogFactory.getLog(GapPatternPostProcessor.class);
 	private final Collection<GapPatternFolderSet> folders = new LinkedList<>();
+	private String searchPattern = "(?<!\\bnew\\W)\\b(%s)(?=[^a-zA-Z\\d_$])(?!\\W+eINSTANCE\\b)";
 	private String replacementPattern = "$1Gen";
 	protected URIConverter uriConverter = new ExtensibleURIConverterImpl();
 
@@ -50,13 +48,17 @@ public class GapPatternPostProcessor extends AbstractWorkflowComponent2 {
 		this.folders.add(folders);
 	}
 
+	public void setSearchPattern(String searchPattern) {
+		this.searchPattern = searchPattern;
+	}
+
 	public void setReplacementPattern(String replacementPattern) {
 		this.replacementPattern = replacementPattern;
 	}
 
 	@Override
 	protected void invokeInternal(WorkflowContext arg0, ProgressMonitor arg1, Issues arg2) {
-		arg1.beginTask("Starting Gen-Pattern post processing", folders.size());
+		arg1.beginTask("Starting Gap-Pattern post processing", folders.size());
 		for (GapPatternFolderSet set : folders) {
 			try {
 				List<Path> manualFolders = set.getManualSourceFolders().stream()
@@ -103,7 +105,7 @@ public class GapPatternPostProcessor extends AbstractWorkflowComponent2 {
 					Files.move(processFile, targetPath, StandardCopyOption.REPLACE_EXISTING);
 					
 					String content = new String(Files.readAllBytes(targetPath), charset);
-					content = content.replaceAll(String.format(CLASSNAME_MATCHER_PATTERN, oldClassName), 
+					content = content.replaceAll(String.format(searchPattern, oldClassName), 
 							replacementPattern);
 					
 					Files.write(targetPath, content.getBytes(charset));

--- a/bundles/tools.mdsd.ecoreworkflow.mwe2lib/src/tools/mdsd/ecoreworkflow/mwe2lib/component/GapPatternPostProcessor.java
+++ b/bundles/tools.mdsd.ecoreworkflow.mwe2lib/src/tools/mdsd/ecoreworkflow/mwe2lib/component/GapPatternPostProcessor.java
@@ -34,20 +34,46 @@ public class GapPatternPostProcessor extends AbstractWorkflowComponent2 {
 
 	private static final Log LOG = LogFactory.getLog(GapPatternPostProcessor.class);
 	private final Collection<GapPatternFolderSet> folders = new LinkedList<>();
+
+	/**
+	 * @see GapPatternPostProcessor.setSearchPattern(String searchPattern)
+	 */
 	private String searchPattern = "(?<!\\bnew\\W)\\b(%s)(?=[^a-zA-Z\\d_$])(?!\\W+eINSTANCE\\b)";
+
 	private String replacementPattern = "$1Gen";
+
 	protected URIConverter uriConverter = new ExtensibleURIConverterImpl();
 
 	private Charset charset = StandardCharsets.UTF_8;
-	
+
 	public void setCharset(Charset charset) {
 		this.charset = charset;
 	}
-	
+
 	public void addFolders(GapPatternFolderSet folders) {
 		this.folders.add(folders);
 	}
 
+	/**
+	 *  Sets the regex which is used to find the occurrences which are supposed to be replaced. The string
+	 *  should contain one string placeholder (%s), which will be used to insert the original class name
+	 *  during execution of this component.
+	 * 
+	 *  If not set, the following default case will be used. The default replacement pattern expects one 
+	 *  matching group. If you adapt this regex make sure to adapt the replacement pattern as well.
+	 *  <code>
+	 *      "(?<!\\bnew\\W)\\b(%s)(?=[^a-zA-Z\\d_$])(?!\\W+eINSTANCE\\b)"
+	 *  </code>
+	 *  It comprises of the following aspects:
+	 *  * <code>(%s)</code>: the original class name (inserted by String.format)
+	 *  * <code>\\b(%s)(?=[^a-zA-Z\\d_$])</code>: the original class name as separate word (preceeded 
+	 *    by a word boundary and not followed by an alphanumerical, underscore or an dollar sign (positive 
+	 *    lookahead). We can not use word boundary (\b) here as it does not prevent the latter two. 
+	 *  * <code>(?<!\\bnew\\W)</code>: not preceeded by "new " (negative lookbehind) to exclude explicit
+	 *    constructor calls.
+	 *  * <code>(?!\\W+eINSTANCE\\b)</code>: not followed by "eINSTANCE" to exclude static eINSTANCE fields
+	 *    in interfaces (negative lookahead).
+	 */
 	public void setSearchPattern(String searchPattern) {
 		this.searchPattern = searchPattern;
 	}

--- a/features/tools.mdsd.ecoreworkflow.mwe2lib.feature/feature.xml
+++ b/features/tools.mdsd.ecoreworkflow.mwe2lib.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.mdsd.ecoreworkflow.mwe2lib.feature"
       label="MDSD.tools EcoreWorkflow MWE2 Library"
-      version="0.1.0.qualifier"
+      version="0.1.1.qualifier"
       plugin="org.palladiosimulator.branding">
 
    <description url="http://www.example.com/description">

--- a/features/tools.mdsd.ecoreworkflow.mwe2lib.xtext.feature/feature.xml
+++ b/features/tools.mdsd.ecoreworkflow.mwe2lib.xtext.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.mdsd.ecoreworkflow.mwe2lib.xtext.feature"
       label="MDSD.tools EcoreWorkflow MWE2 Library for Xtext"
-      version="0.1.0.qualifier">
+      version="0.1.1.qualifier">
 
    <description url="http://www.example.com/description">
       [Enter Feature Description here.]

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.4.2</version>
+		<version>0.4.5</version>
 	</parent>
 	<groupId>tools.mdsd.ecoreworkflow</groupId>
 	<artifactId>parent</artifactId>	

--- a/releng/tools.mdsd.ecoreworkflow.updatesite/category.xml
+++ b/releng/tools.mdsd.ecoreworkflow.updatesite/category.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/tools.mdsd.ecoreworkflow.mwe2lib.feature_0.1.0.qualifier.jar" id="tools.mdsd.ecoreworkflow.mwe2lib.feature" version="0.1.0.qualifier">
+   <feature url="features/tools.mdsd.ecoreworkflow.mwe2lib.feature_0.1.0.qualifier.jar" id="tools.mdsd.ecoreworkflow.mwe2lib.feature" version="0.1.1.qualifier">
       <category name="ecoreworkflow"/>
    </feature>
-   <feature url="features/tools.mdsd.ecoreworkflow.mwe2lib.xtext.feature_0.1.0.qualifier.jar" id="tools.mdsd.ecoreworkflow.mwe2lib.xtext.feature" version="0.1.0.qualifier">
+   <feature url="features/tools.mdsd.ecoreworkflow.mwe2lib.xtext.feature_0.1.0.qualifier.jar" id="tools.mdsd.ecoreworkflow.mwe2lib.xtext.feature" version="0.1.1.qualifier">
       <category name="ecoreworkflow"/>
    </feature>
    <category-def name="ecoreworkflow" label="MDSD Tools Ecore Workflow"/>


### PR DESCRIPTION
Adapted GapPatternPostProcessor to exclude the following from renaming to *Gen:
* `eINSTANCE` field (as e. g. in factory interface; needed to support factory interface extensions)
* explicit constructor ivocations, that is, if classname is preceeded by `new` (needed in static `init()` of generated factory) 