### PR TITLE
Adapt to changed Xtext base class

### DIFF
--- a/bundles/tools.mdsd.ecoreworkflow.mwe2lib.xtext/src/tools/mdsd/ecoreworkflow/mwe2lib/xtext/config/TychoStandardLayoutProjectConfig.xtend
+++ b/bundles/tools.mdsd.ecoreworkflow.mwe2lib.xtext/src/tools/mdsd/ecoreworkflow/mwe2lib/xtext/config/TychoStandardLayoutProjectConfig.xtend
@@ -20,7 +20,6 @@ class TychoStandardLayoutProjectConfig extends StandardProjectConfig {
 			case genericIde: bundlesFolder
 			case eclipsePlugin: bundlesFolder
 			case eclipsePluginTest: testsFolder
-			case ideaPlugin: bundlesFolder
 			case web: bundlesFolder
 		}
 		rootPath + '/' + folderPrefix + '/' + project.name


### PR DESCRIPTION
Xtext removed support for specifying IntelliJ plugin paths with it most recent version. This PR adapts the Tycho layout to avoid compile errors.

see: https://github.com/eclipse/xtext-core/issues/1427