### PR TITLE
Review: Fix path issues

### DIFF
--- a/bundles/tools.mdsd.ecoreworkflow.mwe2lib/src/tools/mdsd/ecoreworkflow/mwe2lib/component/RegexComponent.java
+++ b/bundles/tools.mdsd.ecoreworkflow.mwe2lib/src/tools/mdsd/ecoreworkflow/mwe2lib/component/RegexComponent.java
@@ -1,6 +1,7 @@
 package tools.mdsd.ecoreworkflow.mwe2lib.component;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
@@ -14,6 +15,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
@@ -50,8 +52,9 @@ public class RegexComponent extends AbstractWorkflowComponent2 {
 	protected void invokeInternal(WorkflowContext arg0, ProgressMonitor arg1, Issues arg2) {
 		arg1.beginTask("Replacing patterns for files", replacements.size());
 		for (Replacement replacement : replacements) {
+			
 			try {
-				List<Path> filesToProcess = replacement.getFilenames().stream().map(Paths::get).collect(Collectors.toList());
+				List<Path> filesToProcess = replacement.getFilenames().stream().map(v ->transformFileStringToPath(v)).filter(Objects::nonNull).map(Paths::get).collect(Collectors.toList());
 				if (replacement.getDirectory() != null && replacement.getWildcard() != null) {
 				    final PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + replacement.getWildcard());
 				    Files.walkFileTree(Paths.get(this.convertUri(URI.createURI(replacement.getDirectory()))), new SimpleFileVisitor<Path>() {
@@ -102,5 +105,12 @@ public class RegexComponent extends AbstractWorkflowComponent2 {
 			return uriConverter.normalize(uri).toFileString();
 		}
 	}
-
+	private java.net.URI transformFileStringToPath(String uri) {
+			try {
+				return new java.net.URI(uri);
+			} catch (URISyntaxException e) {
+				e.printStackTrace();
+				return null;
+			}
+	}
 }

--- a/bundles/tools.mdsd.ecoreworkflow.mwe2lib/src/tools/mdsd/ecoreworkflow/mwe2lib/component/RegexComponent.java
+++ b/bundles/tools.mdsd.ecoreworkflow.mwe2lib/src/tools/mdsd/ecoreworkflow/mwe2lib/component/RegexComponent.java
@@ -1,6 +1,7 @@
 package tools.mdsd.ecoreworkflow.mwe2lib.component;
 
 import java.io.IOException;
+import java.io.File;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -52,9 +53,8 @@ public class RegexComponent extends AbstractWorkflowComponent2 {
 	protected void invokeInternal(WorkflowContext arg0, ProgressMonitor arg1, Issues arg2) {
 		arg1.beginTask("Replacing patterns for files", replacements.size());
 		for (Replacement replacement : replacements) {
-			
 			try {
-				List<Path> filesToProcess = replacement.getFilenames().stream().map(v ->transformFileStringToPath(v)).filter(Objects::nonNull).map(Paths::get).collect(Collectors.toList());
+				List<Path> filesToProcess = replacement.getFilenames().stream().map(v -> new File(v).toURI()).map(Paths::get).collect(Collectors.toList());
 				if (replacement.getDirectory() != null && replacement.getWildcard() != null) {
 				    final PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + replacement.getWildcard());
 				    Files.walkFileTree(Paths.get(this.convertUri(URI.createURI(replacement.getDirectory()))), new SimpleFileVisitor<Path>() {
@@ -104,13 +104,5 @@ public class RegexComponent extends AbstractWorkflowComponent2 {
 		else {
 			return uriConverter.normalize(uri).toFileString();
 		}
-	}
-	private java.net.URI transformFileStringToPath(String uri) {
-			try {
-				return new java.net.URI(uri);
-			} catch (URISyntaxException e) {
-				e.printStackTrace();
-				return null;
-			}
 	}
 }


### PR DESCRIPTION
##
Currently the regex component fails on windows, if invoked by maven directly and not invoked by eclipse.
### Exception: 
Illegal char <:> at index 2: /C:\Users\Martin WIttlinger\OneDrive - bwedu\Uni zeugs\Agile Werkzeuge\Palladio-Core-PCM/bundles/org.palladiosimulator.pcm.editor/src/org/palladiosimulator/pcm/allocation/presentation/AllocationEditor.java

<details><summary>## stacktrace</summary>
5471 ERROR Mwe2Launcher       - Problems running workflow generate.editor: Illegal char <:> at index 2: /C:\Users\Martin WIttlinger\OneDrive - bwedu\Uni zeugs\Agile Werkzeuge\Palladio-Core-PCM/bundles/org.palladiosimulator.pcm.editor/src/org/palladiosimulator/pcm/allocation/presentation/AllocationEditor.java
java.lang.RuntimeException: Problems running workflow generate.editor: Illegal char <:> at index 2: /C:\Users\Martin WIttlinger\OneDrive - bwedu\Uni zeugs\Agile Werkzeuge\Palladio-Core-PCM/bundles/org.palladiosimulator.pcm.editor/src/org/palladiosimulator/pcm/allocation/presentation/AllocationEditor.java
        at org.eclipse.emf.mwe2.launch.runtime.Mwe2Runner.run(Mwe2Runner.java:105)
        at org.eclipse.emf.mwe2.launch.runtime.Mwe2Runner.run(Mwe2Runner.java:63)
        at org.eclipse.emf.mwe2.launch.runtime.Mwe2Runner.run(Mwe2Runner.java:53)
        at org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher.run(Mwe2Launcher.java:79)
        at org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher.main(Mwe2Launcher.java:37)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:282)
        at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.nio.file.InvalidPathException: Illegal char <:> at index 2: /C:\Users\Martin WIttlinger\OneDrive - bwedu\Uni zeugs\Agile Werkzeuge\Palladio-Core-PCM/bundles/org.palladiosimulator.pcm.editor/src/org/palladiosimulator/pcm/allocation/presentation/AllocationEditor.java
        at java.base/sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
        at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
        at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
        at java.base/sun.nio.fs.WindowsPath.parse(WindowsPath.java:92)
        at java.base/sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:229)
        at java.base/java.nio.file.Path.of(Path.java:147)
        at java.base/java.nio.file.Paths.get(Paths.java:69)
        at tools.mdsd.ecoreworkflow.mwe2lib.component.RegexComponent.lambda$1(RegexComponent.java)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
        at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1654)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
        at tools.mdsd.ecoreworkflow.mwe2lib.component.RegexComponent.invokeInternal(RegexComponent.java:57)
        at org.eclipse.emf.mwe.core.lib.AbstractWorkflowComponent.invoke(AbstractWorkflowComponent.java:133)
        at org.eclipse.emf.mwe.core.lib.Mwe2Bridge.invoke(Mwe2Bridge.java:35)
        at org.eclipse.emf.mwe.core.lib.AbstractWorkflowComponent.invoke(AbstractWorkflowComponent.java:213)
        at org.eclipse.emf.mwe2.runtime.workflow.AbstractCompositeWorkflowComponent.invoke(AbstractCompositeWorkflowComponent.java:38)
        at org.eclipse.emf.mwe2.runtime.workflow.Workflow.run(Workflow.java:21)
        at org.eclipse.emf.mwe2.launch.runtime.Mwe2Runner.run(Mwe2Runner.java:103)
        ... 10 more
</details>
Converting the filepath to an URI fixes the problem.

## Testing

I tested this fix only on windows, maybe some1 wants to test it on macOS and linux. 
The bugfix works inside eclipse and for maven. A testcase is missing but could be added after my last exam (25.09).