### PR TITLE
Migrated to 2020-12

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,11 +3,11 @@
 	<extension>
 		<groupId>org.eclipse.tycho.extras</groupId>
 		<artifactId>tycho-pomless</artifactId>
-		<version>1.7.0</version>
+		<version>2.1.0</version>
 	</extension>
 	<extension>
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>tycho-tp-refresh-maven-plugin</artifactId>
-		<version>0.2.4</version>
+		<version>0.2.6</version>
 	</extension>
 </extensions>

--- a/bundles/tools.mdsd.ecoreworkflow.umlecoregenerator/META-INF/MANIFEST.MF
+++ b/bundles/tools.mdsd.ecoreworkflow.umlecoregenerator/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: tools.mdsd.ecoreworkflow.umlecoregenerator
 Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: tools.mdsd.ecoreworkflow.umlgenerator
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.eclipse.emf.mwe2.lib,
+Require-Bundle: org.eclipse.emf.mwe2.lib;bundle-version="2.12.0",
  org.eclipse.emf.mwe2.runtime,
  org.eclipse.emf.codegen.ecore,
  org.eclipse.uml2.codegen.ecore,

--- a/bundles/tools.mdsd.ecoreworkflow.umlecoregenerator/src/tools/mdsd/ecoreworkflow/umlecoregenerator/UMLEcoreGenerator.java
+++ b/bundles/tools.mdsd.ecoreworkflow.umlecoregenerator/src/tools/mdsd/ecoreworkflow/umlecoregenerator/UMLEcoreGenerator.java
@@ -1,18 +1,7 @@
 package tools.mdsd.ecoreworkflow.umlecoregenerator;
 
-import org.apache.log4j.Logger;
-import org.eclipse.emf.codegen.ecore.generator.Generator;
-import org.eclipse.emf.codegen.ecore.genmodel.GenModel;
-import org.eclipse.emf.codegen.ecore.genmodel.generator.GenBaseGeneratorAdapter;
-import org.eclipse.emf.codegen.merge.java.JControlModel;
-import org.eclipse.emf.common.util.BasicMonitor;
-import org.eclipse.emf.common.util.Diagnostic;
-import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.codegen.ecore.generator.GeneratorAdapterFactory;
 import org.eclipse.emf.mwe2.ecore.EcoreGenerator;
-import org.eclipse.emf.mwe2.runtime.workflow.IWorkflowContext;
 import org.eclipse.uml2.codegen.ecore.genmodel.GenModelPackage;
 
 /**
@@ -24,90 +13,15 @@ public class UMLEcoreGenerator extends EcoreGenerator {
     static {
         GenModelPackage.eINSTANCE.getEFactoryInstance();
     }
-    
-    private static Logger log = Logger.getLogger(UMLEcoreGenerator.class);
-    private final ResourceSet resSet = new ResourceSetImpl();
-    private String genModel;
-    private boolean generateModel = true;
-    private boolean generateEdit;
-    private boolean generateEditor;
-    
+
     public UMLEcoreGenerator() {
-        setResourceSet(resSet);
-    }
-    
-    @Override
-    public void setGenModel(String genModel) {
-        this.genModel = genModel;
-        super.setGenModel(genModel);
-    }
-    
-    public void setGenerateModel(boolean generateModel) {
-        this.generateModel = generateModel;
+        super();
+        registerUMLGeneratorAdapterFactory();
     }
 
-    @Override
-    public void setGenerateEdit(boolean generateEdit) {
-        this.generateEdit = generateEdit;
-        super.setGenerateEdit(generateEdit);
-    }
-
-    @Override
-    public void setGenerateEditor(boolean generateEditor) {
-        this.generateEditor = generateEditor;
-        super.setGenerateEditor(generateEditor);
-    }
-
-    @Override
-    public void invoke(IWorkflowContext ctx) {
-        Resource resource = resSet.getResource(URI.createURI(genModel), true);
-        final GenModel genModel = (GenModel) resource.getContents().get(0);
-        genModel.setCanGenerate(true);
-        genModel.reconcile();
-        createGenModelSetup().registerGenModel(genModel);
-
-        Generator generator = new Generator() {
-            @Override
-            public JControlModel getJControlModel() {
-                return new JControlModel(){
-                    @Override
-                    public boolean canMerge() {
-                        return false;
-                    }
-                };
-            }
-        };
-        // registration of genmodel adapter for UML genmodels
-        generator.getAdapterFactoryDescriptorRegistry().addDescriptor(GenModelPackage.eNS_URI,
-                    new GeneratorAdapterDescriptor(getTypeMapper(), getLineDelimiter()));
-        
-        log.info("generating EMF code for "+this.genModel);
-        generator.getAdapterFactoryDescriptorRegistry().addDescriptor(GenModelPackage.eNS_URI,
+    protected void registerUMLGeneratorAdapterFactory() {
+        GeneratorAdapterFactory.Descriptor.Registry.INSTANCE.addDescriptor(GenModelPackage.eNS_URI,
                 new GeneratorAdapterDescriptor(getTypeMapper(), getLineDelimiter()));
-        generator.setInput(genModel);
-
-        // added condition for model code generation
-        if (generateModel) {
-            Diagnostic diagnostic = generator.generate(genModel, GenBaseGeneratorAdapter.MODEL_PROJECT_TYPE,
-                    new BasicMonitor());
-            if (diagnostic.getSeverity() != Diagnostic.OK)
-                log.info(diagnostic);            
-        }
-
-        if (generateEdit) {
-            Diagnostic editDiag = generator.generate(genModel, GenBaseGeneratorAdapter.EDIT_PROJECT_TYPE,
-                    new BasicMonitor());
-            if (editDiag.getSeverity() != Diagnostic.OK)
-                log.info(editDiag);
-        }
-
-        if (generateEditor) {
-            Diagnostic editorDiag = generator.generate(genModel, GenBaseGeneratorAdapter.EDITOR_PROJECT_TYPE,
-                    new BasicMonitor());
-            if (editorDiag.getSeverity() != Diagnostic.OK)
-                log.info(editorDiag);
-        }
-        
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.5.5</version>
+		<version>0.7.0</version>
 	</parent>
 	<groupId>tools.mdsd.ecoreworkflow</groupId>
 	<artifactId>parent</artifactId>	

--- a/releng/tools.mdsd.ecoreworkflow.targetplatform/tp.target
+++ b/releng/tools.mdsd.ecoreworkflow.targetplatform/tp.target
@@ -2,16 +2,16 @@
 <?pde version="3.8"?><target name="tools.mdsd.ecoreworkflow Target Platform" sequenceNumber="1">
 <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-        <unit id="org.eclipse.xtext.sdk.feature.group" version="2.22.0.v20200602-1533" />
-        <repository location="http://download.eclipse.org/releases/2020-06/202006171000" />
+        <unit id="org.eclipse.xtext.sdk.feature.group" version="2.24.0.v20201130-1016" />
+        <repository location="http://download.eclipse.org/releases/2020-12/202012161000" />
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-        <unit id="tools.mdsd.library.standalone.initialization.core.feature.feature.group" version="0.1.0.202004172117" />
+        <unit id="tools.mdsd.library.standalone.initialization.core.feature.feature.group" version="0.0.0" />
         <repository location="https://updatesite.mdsd.tools/library-standaloneinitialization/releases/latest/" />
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
         <repository location="https://updatesite.mdsd.tools/build-licensefeature/releases/latest/"/>
-        <unit id="tools.mdsd.license.epl2.feature.group" version="1.0.0"/>
+        <unit id="tools.mdsd.license.epl2.feature.group" version="0.0.0"/>
     </location>
 </locations>
 </target>


### PR DESCRIPTION
The most recent version of MWE contains the flag to switch off model code generation, so we do not have to duplicate this functionality anymore. For details, see eclipse/mwe#165