### PR TITLE
Change version of UML Ecore Generator to 1.1.0

### DIFF
--- a/features/tools.mdsd.ecoreworkflow.umlecoregenerator.feature/feature.xml
+++ b/features/tools.mdsd.ecoreworkflow.umlecoregenerator.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.mdsd.ecoreworkflow.umlecoregenerator.feature"
       label="UML Ecore Generator Feature"
-      version="1.0.0.qualifier"      
+      version="1.1.0.qualifier"
       license-feature="tools.mdsd.license.epl2"
       license-feature-version="1.0.0">
 


### PR DESCRIPTION
Forgot to increase the version to indicate a breaking change because of a stronger dependency requirement.